### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @items.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,8 +35,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @items.destroy
-    redirect_to root_path
+    if @items.user_id == current_user.id
+      @items.destroy
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,8 +37,8 @@ class ItemsController < ApplicationController
   def destroy
     if @items.user_id == current_user.id
       @items.destroy
-      redirect_to root_path
     end
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id  == @items.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", item_path(item.id), method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@items.id), method: :delete, class:"item-destroy" %>
       <% else %>  
     <%# 商品が売れていない場合はこちらを表示しましょう %>
        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id  == @items.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(item.id), method: :delete, class:"item-destroy" %>
       <% else %>  
     <%# 商品が売れていない場合はこちらを表示しましょう %>
        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,5 @@ Rails.application.routes.draw do
   get 'items/index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
-
+  resources :items
 end


### PR DESCRIPTION
# what
商品削除機能の実装

# why
destroyルーティングの設定
削除ボタンの実装
destroyアクションの設定

＜提出動画＞
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画：https://gyazo.com/a4840e09de15a58b5969bcdb36b3d18d

ご確認よろしくお願いします。